### PR TITLE
Remove style check for method names

### DIFF
--- a/src/main/resources/scalastyle-config.xml
+++ b/src/main/resources/scalastyle-config.xml
@@ -85,12 +85,6 @@
             <parameter name="maxLength"><![CDATA[100]]></parameter>
         </parameters>
     </check>
-    <check level="error" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
-        <parameters>
-            <parameter name="regex"><![CDATA[^[A-Za-z\\*][A-Za-z0-9]*$]]></parameter>
-            <parameter name="ignoreRegex">`.*`</parameter>
-        </parameters>
-    </check>
     <check level="error" class="org.scalastyle.scalariform.ClassTypeParameterChecker" enabled="false">
         <parameters>
             <parameter name="regex"><![CDATA[^[A-Za-z]*$]]></parameter>


### PR DESCRIPTION
I'd like to add a builder object to our core library and would like to alias the append methods with `++=` (as is quite common in Scala). Unfortunately the style checker doesn't like that.
I could add `++=` as an exception, however I'm wondering if we should remove he method naming check altogether. We do want to avoid wacky symbolic names, however those are also easily caught in a code review. Thoughts?